### PR TITLE
Replace deprecated Task.leftshift method call

### DIFF
--- a/src/main/groovy/com/heroku/sdk/gradle/HerokuPlugin.groovy
+++ b/src/main/groovy/com/heroku/sdk/gradle/HerokuPlugin.groovy
@@ -15,7 +15,7 @@ class HerokuPlugin implements Plugin<Project> {
             ext.resolvePathsAndValidate()
         }
 
-        project.task('deployHeroku') << {
+        project.task('deployHeroku').doLast {
             List<File> files = ext.getIncludedFiles(project.rootDir)
             if (project.heroku.includeBuildDir) files << project.buildDir
 


### PR DESCRIPTION
Task.leftshit (<<) was deprecated and throws a warning with newer Gradle version. 
This tiny fix solves this.