### PR TITLE
Refactors deployHeroku task into standalone class, sets task group an…

### DIFF
--- a/src/main/groovy/com/heroku/sdk/gradle/DeployHerokuTask.groovy
+++ b/src/main/groovy/com/heroku/sdk/gradle/DeployHerokuTask.groovy
@@ -1,0 +1,46 @@
+package com.heroku.sdk.gradle
+
+import javax.inject.Inject
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Gradle Task that deploys Gradle based JVM applications directly to Heroku
+ * without pushing to a Git repository.
+ */
+class DeployHerokuTask extends DefaultTask {
+
+    /**
+     * The heroku {} block in the build script.
+     */
+    HerokuPluginExtension ext;
+
+    @Inject
+    DeployHerokuTask(HerokuPluginExtension ext) {
+        description = "Deploys JVM web-application directly to Heroku without pushing to a Git repository."
+        group = "Heroku"
+        this.ext = ext
+    }
+
+    @TaskAction
+    void deploy() {
+        File includeRootDir = project.heroku.includeRootDir ?: project.rootDir
+        List<File> files = ext.getIncludedFiles(includeRootDir)
+        if (project.heroku.includeBuildDir) files << project.buildDir
+
+        GradleApp app = new GradleApp(
+                (String) project.heroku.appName,
+                includeRootDir,
+                (File) project.buildDir,
+                (List<String>) project.heroku.buildpacks,
+                project.logger)
+
+        app.deploy(
+                (List<File>) files,
+                (Map<String,String>) project.heroku.configVars,
+                (String) project.heroku.jdkVersion,
+                (Map<String,String>) project.heroku.processTypes,
+                (String) project.heroku.slugFilename)
+    }
+}

--- a/src/main/groovy/com/heroku/sdk/gradle/HerokuPlugin.groovy
+++ b/src/main/groovy/com/heroku/sdk/gradle/HerokuPlugin.groovy
@@ -12,24 +12,6 @@ class HerokuPlugin implements Plugin<Project> {
             ext.resolvePathsAndValidate()
         }
 
-        project.task('deployHeroku').doLast {
-            File includeRootDir = project.heroku.includeRootDir ?: project.rootDir
-            List<File> files = ext.getIncludedFiles(includeRootDir)
-            if (project.heroku.includeBuildDir) files << project.buildDir
-
-            GradleApp app = new GradleApp(
-                    (String) project.heroku.appName,
-                    includeRootDir,
-                    (File) project.buildDir,
-                    (List<String>) project.heroku.buildpacks,
-                    project.logger)
-
-            app.deploy(
-                (List<File>) files,
-                (Map<String,String>) project.heroku.configVars,
-                (String) project.heroku.jdkVersion,
-                (Map<String,String>) project.heroku.processTypes,
-                (String) project.heroku.slugFilename)
-        }
+        project.tasks.create('deployHeroku', DeployHerokuTask.class, ext)
     }
 }


### PR DESCRIPTION
Sets the `group` and `description` fields of the `deployHeroku` task such that information about the task is printed in the output of `gradle tasks`:
![Screen Shot 2020-02-20 at 5 49 31 AM](https://user-images.githubusercontent.com/1471110/74940889-fc40c080-53a6-11ea-88ad-99afaf5b6525.png)

### **Alternate Constructor-less Implementation**

Replace `List<File> files = ext.getIncludedFiles(includeRootDir)` with `List<File> files = project.heroku.includedFiles(includeRootDir)` and set the `group` and `description` fields inline when the task is created:
```
DeployHerokuTask deployHerokuTask = project.tasks.create('deployHeroku', DeployHerokuTask.class)
deployHerokuTask.description = "Deploys JVM web-application directly to Heroku without pushing to a Git repository."
deployHerokuTask.group = "Heroku"
```